### PR TITLE
Seconds multiplier typo

### DIFF
--- a/archive/tasks/images.js
+++ b/archive/tasks/images.js
@@ -11,6 +11,6 @@ page.open(address, function (status) {
         window.setTimeout(function () {
             page.render(outfile);
             phantom.exit();
-        }, secondsToWait * 100);
+        }, secondsToWait * 1000);
     }
 });


### PR DESCRIPTION
Current: secondsToWait \* 100
Correct: secondsToWait \* 1000 
